### PR TITLE
Email null

### DIFF
--- a/src/Entity/Customer/Customer.php
+++ b/src/Entity/Customer/Customer.php
@@ -92,7 +92,7 @@ class Customer
             $customer["created_at"] = $this->getCreatedAt();
         }
 
-        if (!$this->identifier->isEmail()) {
+        if (!$this->identifier->isEmail() && !is_null($this->getEmail())) {
             $customer['email'] = $this->getEmail();
         }
 

--- a/tests/unit/Entity/Customer/CustomerTest.php
+++ b/tests/unit/Entity/Customer/CustomerTest.php
@@ -38,9 +38,11 @@ class CustomerTest extends TestCase
 
     public function testValidEmail()
     {
+        $email = "valid@email.com";
         $identifier = new Identifier("123");
-        $customer   = new Customer($identifier, "valid@email.com");
+        $customer   = new Customer($identifier, $email);
         $this->assertInstanceOf(Customer::class, $customer);
+        $this->assertEquals(['email' => $email], $customer->toArray());
     }
 
     public function testEmailNull()
@@ -48,5 +50,6 @@ class CustomerTest extends TestCase
         $identifier = new Identifier("123");
         $customer   = new Customer($identifier, null);
         $this->assertInstanceOf(Customer::class, $customer);
+        $this->assertEquals([], $customer->toArray());
     }
 }


### PR DESCRIPTION
Quando um usuário estava sendo atualizado sem atualizar o e-mail ele estava removendo o e-mail por enviar o e-mail como nulo.